### PR TITLE
Use `gcloud app` instead of `gcloud preview app`

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ To run the starter app, complete the following steps:
 Deploy to your AppEngine instance:
 
 ```sh
-gcloud preview app deploy
+gcloud app deploy
 ```
 
 You can also run this locally using the app-engine


### PR DESCRIPTION
We should use `gcloud app` instead of `gcloud preview app` which will go away soon.
